### PR TITLE
feat: Implement podcast analysis pipeline and GH Pages site

### DIFF
--- a/.github/workflows/extract-transcript.yml
+++ b/.github/workflows/extract-transcript.yml
@@ -104,6 +104,8 @@ jobs:
           # Create data directory if it doesn't exist
           os.makedirs('data/transcripts', exist_ok=True)
           
+          primary_id_for_filename = os.environ.get('EPISODE_ID_FROM_ZIP')
+          
           # Load episode links data for titles and release dates if available
           episode_metadata = {}
           episode_links_path = 'data/episodes/episode_links.json'
@@ -255,6 +257,7 @@ jobs:
                   output_data = {
                       "episode_title": episode_title,
                       "apple_id": apple_id,
+                      "filename_primary_id": episode_id, # This episode_id is from path_parts[2]
                   }
                   
                   # Add Spotify ID if available

--- a/.github/workflows/gemini-analyzer.yml
+++ b/.github/workflows/gemini-analyzer.yml
@@ -13,10 +13,12 @@ on:
         type: boolean
         default: false
 
-# Add permissions to allow reading artifacts from other workflows
+# Add permissions to allow reading artifacts from other workflows and deploying to GitHub Pages
 permissions:
   actions: read
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   analyze:
@@ -86,3 +88,54 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+  build-and-deploy-site:
+    needs: analyze
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Get all history
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+      
+      - name: Run Data Aggregation Script
+        run: |
+          python scripts/aggregate_data.py
+
+      - name: Commit Updated site_data.json
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "actions@github.com"
+          
+          # Check if docs/site_data.json has changed or is new
+          if ! git diff --quiet docs/site_data.json; then
+            echo "docs/site_data.json has changed or is new. Committing and pushing."
+            git add docs/site_data.json
+            git commit -m "Update site_data.json for GitHub Pages [skip ci]"
+            git push
+          else
+            echo "No changes to docs/site_data.json. Nothing to commit."
+          fi
+          
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/process-episodes.yml
+++ b/.github/workflows/process-episodes.yml
@@ -147,34 +147,38 @@ jobs:
       - name: Create safe filename
         id: safe-filename
         run: |
-          # Use episode ID for filename instead of title
           EPISODE_ID="${{ matrix.episode.apple_id }}"
-          # Fallback to episode_id or spotify_id if apple_id is not available
-          if [ -z "$EPISODE_ID" ]; then
-            EPISODE_ID="${{ matrix.episode.episode_id }}"
+          
+          if [ -z "$EPISODE_ID" ] || [ "$EPISODE_ID" == "null" ]; then
+            EPISODE_ID="${{ matrix.episode.spotify_id }}"
           fi
-          # Final fallback to safe title if no IDs are available
-          if [ -z "$EPISODE_ID" ]; then
-            EPISODE_ID=$(echo "${{ matrix.episode.title }}" | sed 's/[^a-zA-Z0-9]/_/g')
-            echo "Warning: Using title as filename because no episode ID is available"
+          
+          if [ -z "$EPISODE_ID" ] || [ "$EPISODE_ID" == "null" ]; then
+            EPISODE_ID=$(echo "${{ matrix.episode.title }}" | sed 's/[^a-zA-Z0-9]/_/g' | cut -c1-50)
           fi
-          echo "safe_title=$EPISODE_ID" >> $GITHUB_OUTPUT
+          
+          if [ -z "$EPISODE_ID" ]; then
+            echo "Error: No valid ID could be formed for the episode."
+            exit 1
+          fi
+          
+          echo "PRIMARY_ID=$EPISODE_ID" >> $GITHUB_OUTPUT
       
       - name: Zip the Podcasts Cache Folder
         run: |
-          zip -r "${{ steps.safe-filename.outputs.safe_title }}_cache.zip" "$HOME/Library/Group Containers/243LU875E5.groups.com.apple.podcasts/Library/Cache"
+          zip -r "${{ steps.safe-filename.outputs.PRIMARY_ID }}_cache.zip" "$HOME/Library/Group Containers/243LU875E5.groups.com.apple.podcasts/Library/Cache"
       
       - name: Upload Cache Folder to data/raw
         run: |
           mkdir -p data/raw
-          mv "${{ steps.safe-filename.outputs.safe_title }}_cache.zip" "data/raw/${{ steps.safe-filename.outputs.safe_title }}_cache.zip"
-          echo "Cache saved to data/raw/${{ steps.safe-filename.outputs.safe_title }}_cache.zip"
+          mv "${{ steps.safe-filename.outputs.PRIMARY_ID }}_cache.zip" "data/raw/${{ steps.safe-filename.outputs.PRIMARY_ID }}_cache.zip"
+          echo "Cache saved to data/raw/${{ steps.safe-filename.outputs.PRIMARY_ID }}_cache.zip"
       
       - name: Upload Cache as Artifact (backup)
         uses: actions/upload-artifact@v4
         with:
           name: transcript-cache-${{ github.run_id }}-${{ strategy.job-index }}
-          path: "data/raw/${{ steps.safe-filename.outputs.safe_title }}_cache.zip"
+          path: "data/raw/${{ steps.safe-filename.outputs.PRIMARY_ID }}_cache.zip"
       
       # Commit changes to data/raw
       - name: Commit Changes

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Podcast Analysis and "Gegenwartsvorschläge" Viewer
+
+This project automates the process of fetching podcast episodes, extracting transcripts, analyzing them for "Gegenwartsvorschläge" (suggestions of contemporary phenomena) using Gemini, and presenting these suggestions on a searchable static website.
+
+## Project Overview
+
+The core idea is to analyze episodes of the podcast "Die sogenannte Gegenwart" (or any other podcast with a similar format if adapted) to identify and catalogue the "Gegenwartsvorschläge" discussed by the hosts. These suggestions, along with their context and whether they received a "point," are then made available through a GitHub Pages website.
+
+## Data Pipeline
+
+The data pipeline consists of several automated and manually triggered steps, primarily managed through GitHub Actions workflows:
+
+1.  **Fetch Episode Links (`get-podcast-links.yml`):**
+    *   Runs weekly and can be manually dispatched.
+    *   Fetches episode lists from Apple Podcasts and Spotify using `scripts/spotify_fetch.py` for Spotify data.
+    *   Merges these lists, removing duplicates based on release date, and saves the combined list to `data/episodes/episode_links.json`.
+
+2.  **Process Episodes & Cache Transcripts (`process-episodes.yml`):**
+    *   Manually dispatched workflow.
+    *   Takes episode URLs from `data/episodes/episode_links.json`.
+    *   Uses `osascript` on a macOS runner to interact with the Apple Podcasts desktop application.
+    *   For each episode, it navigates to the episode, shows the transcript, and then zips the application's cache directory (which contains the TTML transcript data).
+    *   Saves these zipped cache files to `data/raw/<primary_id>_cache.zip`, where `primary_id` is usually the Apple Podcast ID or Spotify ID.
+
+3.  **Extract Transcripts (`extract-transcript.yml`):**
+    *   Manually dispatched workflow.
+    *   Processes the `_cache.zip` files from `data/raw/`.
+    *   Unzips the archives and extracts the transcript text from the TTML files found within.
+    *   Saves the cleaned transcript data (including speaker information and timestamps) as JSON files in `data/transcripts/<primary_id>_transcript.json`.
+
+4.  **Analyze Transcripts (`gemini-analyzer.yml` - `analyze` job):**
+    *   Manually dispatched workflow.
+    *   Uses `scripts/gemini_analyzer.py` to process transcripts from `data/transcripts/`.
+    *   For each transcript, it calls the Gemini API to:
+        *   Identify "Gegenwartsvorschläge."
+        *   Extract details for each suggestion (proposer, reasoning, tags, whether a point was awarded, etc.).
+        *   Perform a proofreading and correction step on the extracted data.
+    *   Saves the structured analysis results as JSON files in `data/analyses/<primary_id>.json`.
+
+5.  **Aggregate Data & Deploy Site (`gemini-analyzer.yml` - `build-and-deploy-site` job):**
+    *   This job runs automatically after the `analyze` job in the `gemini-analyzer.yml` workflow.
+    *   Uses `scripts/aggregate_data.py` to:
+        *   Read all individual analysis files from `data/analyses/`.
+        *   Combine them with episode metadata from `data/episodes/episode_links.json`.
+        *   Produce a single JSON file: `docs/site_data.json`.
+    *   Commits the updated `docs/site_data.json` to the repository.
+    *   Deploys the content of the `/docs` directory (which includes `index.html`, `style.css`, `main.js`, and `site_data.json`) to GitHub Pages.
+
+## GitHub Pages Site
+
+The static website provides a user-friendly interface to explore the "Gegenwartsvorschläge":
+
+*   **Searchable List:** Allows users to search suggestions by keywords, proposer, or tags.
+*   **Statistics:** Displays interesting statistics, such as the number of suggestions per host, success rates, and popular tags.
+*   **Direct Links:** Provides links to the original podcast episodes on Apple Podcasts and Spotify where available.
+
+The site is automatically updated whenever new analyses are processed and committed via the `gemini-analyzer.yml` workflow.
+
+## Key Scripts
+
+*   **`scripts/spotify_fetch.py`**: Fetches episode data from the Spotify API.
+*   **`scripts/gemini_analyzer.py`**: Analyzes transcripts using the Gemini API to extract "Gegenwartsvorschläge".
+*   **`scripts/aggregate_data.py`**: Consolidates all analysis results and episode metadata into a single file for the web application.
+
+## Manual Workflow Triggers
+
+Most data processing workflows (`process-episodes`, `extract-transcript`, `gemini-analyzer`) are manually triggered via the GitHub Actions UI. This allows for controlled processing and reprocessing if needed.
+The `get-podcast-links` workflow runs on a weekly schedule but can also be manually triggered.
+The deployment of the GitHub Pages site is automated as part of the `gemini-analyzer` workflow.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gegenwartsvorschläge Analyse</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Analyse der Gegenwartsvorschläge</h1>
+    </header>
+
+    <main>
+        <section id="stats-section">
+            <h2>Statistiken</h2>
+            <div id="stats-container">
+                <!-- Statistiken werden hier per JS eingefügt -->
+            </div>
+        </section>
+
+        <section id="search-filter-section">
+            <h2>Suche & Filter</h2>
+            <input type="text" id="search-input" placeholder="Suche...">
+            <select id="filter-proposer">
+                <option value="">Alle Vorschlagende...</option>
+                <!-- Optionen werden hier per JS eingefügt -->
+            </select>
+            <select id="filter-tag">
+                <option value="">Alle Tags...</option>
+                <!-- Optionen werden hier per JS eingefügt -->
+            </select>
+        </section>
+
+        <section id="vorschlaege-list-section">
+            <h2>Vorschläge</h2>
+            <div id="vorschlaege-container">
+                <!-- Vorschläge werden hier per JS eingefügt -->
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>Daten generiert am: <span id="data-generated-date">Lade Datum...</span></p>
+        <!-- Optional: If site_data.json contains a generation date, display it here.
+             For now, we'll leave it static or update if the data provides it. -->
+    </footer>
+
+    <script src="main.js"></script></body>
+</html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,0 +1,211 @@
+// Global variable to store all fetched data
+let allData = [];
+const SITE_DATA_URL = 'site_data.json'; // Or directly 'site_data.json' if in the same folder
+
+// DOMContentLoaded listener
+document.addEventListener('DOMContentLoaded', init);
+
+// Init function
+async function init() {
+    await fetchData(); // Wait for data to be fetched and parsed
+    if (allData.length > 0) {
+        populateFilters(allData);
+        renderVorschlaege(allData);
+        calculateAndDisplayStats(allData);
+        setupEventListeners();
+        updateDataGeneratedDate(); // If you have a date in your data
+    } else {
+        document.getElementById('vorschlaege-container').innerHTML = '<p>Keine Daten geladen oder Daten sind leer.</p>';
+        document.getElementById('stats-container').innerHTML = '<p>Keine Statistiken verfügbar.</p>';
+    }
+}
+
+// Fetch data function
+async function fetchData() {
+    try {
+        const response = await fetch(SITE_DATA_URL);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        allData = data; // Assign to global variable
+        console.log("Daten erfolgreich geladen:", allData);
+    } catch (error) {
+        console.error("Fehler beim Laden der Daten:", error);
+        allData = []; // Ensure allData is empty on error
+    }
+}
+
+// Render Vorschlaege function
+function renderVorschlaege(vorschlaegeArray) {
+    const container = document.getElementById('vorschlaege-container');
+    container.innerHTML = ''; // Clear current content
+
+    if (!vorschlaegeArray || vorschlaegeArray.length === 0) {
+        container.innerHTML = '<p>Keine Ergebnisse gefunden.</p>';
+        return;
+    }
+
+    vorschlaegeArray.forEach(item => {
+        const article = document.createElement('article');
+        
+        // Basic info
+        let htmlContent = `
+            <h3>${item.vorschlag || 'Unbekannter Vorschlag'}</h3>
+            <p><strong>Vorgeschlagen von:</strong> ${item.vorschlagender || 'N/A'} 
+               ${item.ist_hoerer ? ` (Hörer: ${item.hoerer_name || 'N/A'})` : ''}
+            </p>
+            <p><strong>Punkt erhalten:</strong> ${item.punkt_erhalten ? 'Ja' : 'Nein'} 
+               (von: ${item.punkt_von || 'N/A'})
+            </p>
+            <p><strong>Begründung:</strong> ${item.begruendung || 'Keine'}</p>
+            <p><strong>Tags:</strong> ${item.tags && item.tags.length > 0 ? item.tags.join(', ') : 'Keine'}</p>
+            <p><strong>Diskussion ab Sekunde:</strong> ${item.start_zeit_sekunden !== null ? item.start_zeit_sekunden : 'N/A'}</p>
+            <p><strong>Episode:</strong> ${item.episode_title || 'Unbekannter Titel'} 
+               (${item.episode_date || 'Unbekanntes Datum'})
+            </p>
+        `;
+
+        // Episode Links
+        if (item.episode_apple_url) {
+            htmlContent += `<p><a href="${item.episode_apple_url}" target="_blank">Auf Apple Podcasts anhören</a></p>`;
+        }
+        // The key 'url' from combined_episodes.json was Spotify URL
+        if (item.episode_spotify_url) { 
+            htmlContent += `<p><a href="${item.episode_spotify_url}" target="_blank">Auf Spotify anhören</a></p>`;
+        }
+        
+        article.innerHTML = htmlContent;
+        container.appendChild(article);
+    });
+}
+
+// Populate filters function
+function populateFilters(data) {
+    const proposers = new Set();
+    const tags = new Set();
+
+    data.forEach(item => {
+        if (item.vorschlagender) {
+            proposers.add(item.vorschlagender);
+        }
+        if (item.tags && Array.isArray(item.tags)) {
+            item.tags.forEach(tag => tags.add(tag));
+        }
+    });
+
+    const proposerSelect = document.getElementById('filter-proposer');
+    Array.from(proposers).sort().forEach(proposer => {
+        const option = document.createElement('option');
+        option.value = proposer;
+        option.textContent = proposer;
+        proposerSelect.appendChild(option);
+    });
+
+    const tagSelect = document.getElementById('filter-tag');
+    Array.from(tags).sort().forEach(tag => {
+        const option = document.createElement('option');
+        option.value = tag;
+        option.textContent = tag;
+        tagSelect.appendChild(option);
+    });
+}
+
+// Apply filters and search function
+function applyFiltersAndSearch() {
+    const searchText = document.getElementById('search-input').value.toLowerCase();
+    const selectedProposer = document.getElementById('filter-proposer').value;
+    const selectedTag = document.getElementById('filter-tag').value;
+
+    const filteredData = allData.filter(item => {
+        const matchesSearchText = (
+            (item.vorschlag && item.vorschlag.toLowerCase().includes(searchText)) ||
+            (item.begruendung && item.begruendung.toLowerCase().includes(searchText)) ||
+            (item.episode_title && item.episode_title.toLowerCase().includes(searchText)) ||
+            (item.tags && Array.isArray(item.tags) && item.tags.some(tag => tag.toLowerCase().includes(searchText)))
+        );
+        const matchesProposer = !selectedProposer || (item.vorschlagender === selectedProposer);
+        const matchesTag = !selectedTag || (item.tags && Array.isArray(item.tags) && item.tags.includes(selectedTag));
+
+        return matchesSearchText && matchesProposer && matchesTag;
+    });
+
+    renderVorschlaege(filteredData);
+    calculateAndDisplayStats(filteredData);
+}
+
+// Calculate and display stats function
+function calculateAndDisplayStats(data) {
+    const statsContainer = document.getElementById('stats-container');
+    statsContainer.innerHTML = ''; // Clear current stats
+
+    if (!data || data.length === 0) {
+        statsContainer.innerHTML = "<p>Keine Daten für Statistiken vorhanden.</p>";
+        return;
+    }
+
+    // Total suggestions
+    const totalSuggestions = data.length;
+    statsContainer.innerHTML += `<p><strong>Angezeigte Vorschläge:</strong> ${totalSuggestions}</p>`;
+
+    // Suggestions per proposer
+    const suggestionsPerProposer = {};
+    const pointsPerProposer = {};
+    data.forEach(item => {
+        if (item.vorschlagender) {
+            suggestionsPerProposer[item.vorschlagender] = (suggestionsPerProposer[item.vorschlagender] || 0) + 1;
+            if (item.punkt_erhalten) {
+                pointsPerProposer[item.vorschlagender] = (pointsPerProposer[item.vorschlagender] || 0) + 1;
+            }
+        }
+    });
+
+    let proposerStatsHtml = '<h4>Vorschläge pro Person:</h4><ul>';
+    for (const [proposer, count] of Object.entries(suggestionsPerProposer).sort((a,b) => b[1] - a[1])) {
+        const points = pointsPerProposer[proposer] || 0;
+        const successRate = count > 0 ? ((points / count) * 100).toFixed(1) : 0;
+        proposerStatsHtml += `<li>${proposer}: ${count} (Erfolgsrate: ${successRate}%)</li>`;
+    }
+    proposerStatsHtml += '</ul>';
+    statsContainer.innerHTML += proposerStatsHtml;
+
+    // Tag frequency
+    const tagFrequency = {};
+    data.forEach(item => {
+        if (item.tags && Array.isArray(item.tags)) {
+            item.tags.forEach(tag => {
+                tagFrequency[tag] = (tagFrequency[tag] || 0) + 1;
+            });
+        }
+    });
+
+    let tagStatsHtml = '<h4>Tag Häufigkeit:</h4><ul>';
+    for (const [tag, count] of Object.entries(tagFrequency).sort((a,b) => b[1] - a[1]).slice(0, 15)) { // Display top 15 tags
+        tagStatsHtml += `<li>${tag}: ${count}</li>`;
+    }
+    tagStatsHtml += '</ul>';
+    statsContainer.innerHTML += tagStatsHtml;
+}
+
+// Setup event listeners function
+function setupEventListeners() {
+    document.getElementById('search-input').addEventListener('input', applyFiltersAndSearch);
+    document.getElementById('filter-proposer').addEventListener('change', applyFiltersAndSearch);
+    document.getElementById('filter-tag').addEventListener('change', applyFiltersAndSearch);
+}
+
+// Update data generated date (Placeholder)
+function updateDataGeneratedDate() {
+    // This function can be expanded if your site_data.json includes a generation timestamp.
+    // For now, let's assume we don't have it, or set a static date.
+    const dateSpan = document.getElementById('data-generated-date');
+    if (dateSpan) {
+        // Example: If allData has a root-level property like "generated_at"
+        // if (allData.length > 0 && allData[0].data_generation_date_iso) { // Assuming date is on first item or metadata
+        //    dateSpan.textContent = new Date(allData[0].data_generation_date_iso).toLocaleString('de-DE');
+        // } else {
+        dateSpan.textContent = new Date().toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' });
+        // }
+    }
+}
+console.log("main.js geladen.");

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,149 @@
+/* Basic Reset */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    line-height: 1.6;
+    background-color: #f4f4f4;
+    color: #333;
+    padding: 0 20px; /* Add some padding to the sides of the body */
+}
+
+.container {
+    max-width: 960px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem 0;
+    text-align: center;
+    margin-bottom: 20px;
+    border-radius: 8px 8px 0 0; /* Rounded top corners */
+}
+
+header h1 {
+    margin-bottom: 0;
+}
+
+main {
+    padding: 10px; /* Slightly reduced padding if container has its own */
+}
+
+section {
+    margin-bottom: 30px;
+    padding: 20px;
+    background-color: #fff; /* White background for sections */
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+section h2 {
+    color: #333;
+    margin-bottom: 15px;
+    border-bottom: 2px solid #eee;
+    padding-bottom: 10px;
+}
+
+#search-filter-section input[type="text"],
+#search-filter-section select {
+    width: 100%;
+    padding: 12px;
+    margin-bottom: 15px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 16px;
+}
+
+#search-filter-section input[type="text"] {
+    margin-right: 10px; /* Spacing between search and selects if they were inline */
+}
+
+/* Vorschlag Item Styling */
+#vorschlaege-container article {
+    background-color: #f9f9f9;
+    border: 1px solid #e7e7e7;
+    border-radius: 6px;
+    padding: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}
+
+#vorschlaege-container article h3 {
+    color: #0056b3; /* A distinct color for vorschlag title */
+    margin-bottom: 10px;
+}
+
+#vorschlaege-container article p {
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+    color: #555;
+}
+#vorschlaege-container article p strong {
+    color: #333;
+}
+
+#vorschlaege-container article a {
+    color: #007bff;
+    text-decoration: none;
+}
+#vorschlaege-container article a:hover {
+    text-decoration: underline;
+}
+
+/* Stats Container Styling */
+#stats-container div {
+    margin-bottom: 10px;
+    padding: 10px;
+    background-color: #e9ecef;
+    border-radius: 4px;
+}
+#stats-container h4 {
+    margin-top: 15px;
+    margin-bottom: 5px;
+    color: #333;
+}
+#stats-container ul {
+    list-style-type: none;
+    padding-left: 0;
+}
+#stats-container li {
+    padding: 2px 0;
+}
+
+
+footer {
+    text-align: center;
+    padding: 20px 0;
+    margin-top: 30px;
+    font-size: 0.9rem;
+    color: #666;
+    background-color: #333; /* Consistent with header */
+    color: #fff;
+    border-radius: 0 0 8px 8px; /* Rounded bottom corners */
+}
+
+/* Responsive adjustments (optional for basic) */
+@media (max-width: 768px) {
+    body {
+        padding: 0 10px;
+    }
+    .container {
+        margin: 10px auto;
+        padding: 15px;
+    }
+    #search-filter-section input[type="text"],
+    #search-filter-section select {
+        margin-right: 0;
+        margin-bottom: 10px;
+    }
+}

--- a/scripts/aggregate_data.py
+++ b/scripts/aggregate_data.py
@@ -49,7 +49,7 @@ def process_analyses(analyses_dir: str, episode_lookup: Dict[str, Dict[str, Any]
     Processes analysis files, enriches Vorschlaege with episode metadata.
     """
     all_vorschlaege: List[Dict[str, Any]] = []
-    analysis_files = glob.glob(os.path.join(analyses_dir, "*.json"))
+    analysis_files = sorted(glob.glob(os.path.join(analyses_dir, "*.json")))
 
     if not analysis_files:
         logging.warning(f"No analysis files found in directory: {analyses_dir}")

--- a/scripts/aggregate_data.py
+++ b/scripts/aggregate_data.py
@@ -1,0 +1,196 @@
+import json
+import os
+import glob
+import logging
+import argparse
+from typing import List, Dict, Any, Optional
+
+# 1. Constants
+ANALYSES_DIR = "data/analyses"
+EPISODE_LINKS_FILE = "data/episodes/episode_links.json"
+OUTPUT_DIR = "docs"
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, "site_data.json")
+
+# 2. Logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def load_episode_links(filepath: str) -> Dict[str, Dict[str, Any]]:
+    """
+    Loads episode links from a JSON file and creates a lookup dictionary.
+    Keys are apple_id (str) and spotify_id.
+    """
+    episode_lookup: Dict[str, Dict[str, Any]] = {}
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            episodes_data = json.load(f)
+        
+        for episode in episodes_data:
+            if not isinstance(episode, dict):
+                logging.warning(f"Skipping non-dictionary item in episode links: {episode}")
+                continue
+
+            apple_id = episode.get('apple_id')
+            spotify_id = episode.get('spotify_id')
+
+            if apple_id:
+                episode_lookup[str(apple_id)] = episode
+            if spotify_id:
+                episode_lookup[spotify_id] = episode
+        
+        logging.info(f"Loaded {len(episodes_data)} episodes from {filepath}, created {len(episode_lookup)} lookup entries.")
+    except FileNotFoundError:
+        logging.error(f"Episode links file not found: {filepath}")
+    except json.JSONDecodeError:
+        logging.error(f"Error decoding JSON from episode links file: {filepath}")
+    return episode_lookup
+
+def process_analyses(analyses_dir: str, episode_lookup: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Processes analysis files, enriches Vorschlaege with episode metadata.
+    """
+    all_vorschlaege: List[Dict[str, Any]] = []
+    analysis_files = glob.glob(os.path.join(analyses_dir, "*.json"))
+
+    if not analysis_files:
+        logging.warning(f"No analysis files found in directory: {analyses_dir}")
+        return all_vorschlaege
+
+    for file_path in analysis_files:
+        logging.info(f"Processing analysis file: {file_path}")
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                analysis_data = json.load(f)
+
+            if not isinstance(analysis_data, dict):
+                logging.warning(f"Skipping malformed analysis file (not a dict): {file_path}")
+                continue
+
+            # Extract IDs and details from analysis file content
+            filename_primary_id = analysis_data.get('filename_primary_id') # This should be the primary key from the filename
+            analysis_apple_id = str(analysis_data.get('apple_id', ''))
+            analysis_spotify_id = analysis_data.get('spotify_id', '')
+            episode_title_from_analysis = analysis_data.get('episode_title', 'Unknown Title')
+            episode_date_from_analysis = analysis_data.get('episode_date', 'Unknown Date')
+
+            # Determine the best ID to use for lookup in episode_links.json
+            # The filename_primary_id (derived from the original zip) is usually the most reliable.
+            lookup_id = filename_primary_id or analysis_apple_id or analysis_spotify_id
+            
+            episode_metadata: Optional[Dict[str, Any]] = None
+            if lookup_id:
+                episode_metadata = episode_lookup.get(str(lookup_id))
+                if not episode_metadata and analysis_apple_id and analysis_apple_id != lookup_id: # Try apple_id if primary lookup failed
+                    episode_metadata = episode_lookup.get(analysis_apple_id)
+                if not episode_metadata and analysis_spotify_id and analysis_spotify_id != lookup_id: # Try spotify_id if primary lookup failed
+                    episode_metadata = episode_lookup.get(analysis_spotify_id)
+            
+            if not episode_metadata:
+                logging.warning(f"No episode metadata found in lookup for ID '{lookup_id}' from file {file_path}")
+
+            for i, vorschlag_item in enumerate(analysis_data.get('gegenwartsvorschlaege', [])):
+                if not isinstance(vorschlag_item, dict):
+                    logging.warning(f"Skipping malformed vorschlag_item (not a dict) in {file_path}")
+                    continue
+
+                enriched_vorschlag = {**vorschlag_item} # Copy original fields
+
+                # Add/overwrite with episode-level information
+                enriched_vorschlag['episode_title_from_analysis'] = episode_title_from_analysis
+                enriched_vorschlag['episode_date_from_analysis'] = episode_date_from_analysis
+                enriched_vorschlag['episode_apple_id_from_analysis'] = analysis_apple_id
+                enriched_vorschlag['episode_spotify_id_from_analysis'] = analysis_spotify_id
+                enriched_vorschlag['episode_filename_primary_id'] = filename_primary_id
+                
+                # Create a unique ID for the Vorschlag
+                enriched_vorschlag['unique_vorschlag_id'] = f"{filename_primary_id or 'unknown_episode'}_{i}"
+
+
+                if episode_metadata:
+                    enriched_vorschlag['episode_title'] = episode_metadata.get('title', episode_title_from_analysis)
+                    enriched_vorschlag['episode_date'] = episode_metadata.get('release_date', episode_date_from_analysis)
+                    enriched_vorschlag['episode_apple_url'] = episode_metadata.get('apple_url') # Assuming 'apple_url' exists in links
+                    enriched_vorschlag['episode_spotify_url'] = episode_metadata.get('url') # 'url' is spotify URL in combined links
+                    enriched_vorschlag['episode_apple_id'] = str(episode_metadata.get('apple_id', analysis_apple_id))
+                    enriched_vorschlag['episode_spotify_id'] = episode_metadata.get('spotify_id', analysis_spotify_id)
+                else:
+                    enriched_vorschlag['episode_title'] = episode_title_from_analysis
+                    enriched_vorschlag['episode_date'] = episode_date_from_analysis
+                    enriched_vorschlag['episode_apple_url'] = None
+                    enriched_vorschlag['episode_spotify_url'] = None
+                    enriched_vorschlag['episode_apple_id'] = analysis_apple_id
+                    enriched_vorschlag['episode_spotify_id'] = analysis_spotify_id
+
+                # Ensure start_zeit_sekunden is an integer
+                start_zeit_str = vorschlag_item.get('start_zeit')
+                start_zeit_sekunden = None
+                if start_zeit_str is not None:
+                    try:
+                        start_zeit_sekunden = int(str(start_zeit_str).replace('s', ''))
+                    except ValueError:
+                        logging.warning(f"Could not convert start_zeit '{start_zeit_str}' to int for a vorschlag in {file_path}")
+                enriched_vorschlag['start_zeit_sekunden'] = start_zeit_sekunden
+                
+                all_vorschlaege.append(enriched_vorschlag)
+
+        except FileNotFoundError:
+            logging.error(f"Analysis file not found during processing: {file_path}")
+        except json.JSONDecodeError:
+            logging.error(f"Error decoding JSON from analysis file: {file_path}")
+        except Exception as e:
+            logging.error(f"Unexpected error processing file {file_path}: {e}")
+
+    logging.info(f"Processed {len(all_vorschlaege)} Vorschlaege from {len(analysis_files)} analysis files.")
+    return all_vorschlaege
+
+def save_output(data: List[Dict[str, Any]], output_path: str) -> None:
+    """
+    Saves the aggregated data to a JSON file.
+    """
+    try:
+        output_dir = os.path.dirname(output_path)
+        if output_dir: # Ensure output_dir is not an empty string if output_path is just a filename
+             os.makedirs(output_dir, exist_ok=True)
+        
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        logging.info(f"Successfully saved aggregated data to: {output_path}")
+    except OSError as e:
+        logging.error(f"OSError when creating directories or writing file {output_path}: {e}")
+    except Exception as e:
+        logging.error(f"Unexpected error saving output to {output_path}: {e}")
+
+# 3. Main Function
+def main(args):
+    """
+    Main function to orchestrate loading, processing, and saving of data.
+    """
+    logging.info("Starting data aggregation process...")
+    
+    episode_lookup = load_episode_links(args.episode_links_file)
+    
+    if not episode_lookup:
+        logging.warning("Episode lookup is empty. Aggregation might be incomplete.")
+        # Decide if to proceed or exit. For now, proceed.
+        
+    all_vorschlaege_data = process_analyses(args.analyses_dir, episode_lookup)
+    
+    if not all_vorschlaege_data:
+        logging.warning("No Vorschlaege were processed. Output file will be empty or not created if saving empty is handled.")
+        # Depending on requirements, you might want to avoid saving an empty list
+    
+    save_output(all_vorschlaege_data, args.output_file)
+    
+    logging.info("Data aggregation process finished.")
+
+# 7. Script Execution
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Aggregates podcast analysis data for website.")
+    parser.add_argument("--analyses-dir", default=ANALYSES_DIR,
+                        help=f"Directory containing analysis JSON files (default: {ANALYSES_DIR})")
+    parser.add_argument("--episode-links-file", default=EPISODE_LINKS_FILE,
+                        help=f"Path to the episode links JSON file (default: {EPISODE_LINKS_FILE})")
+    parser.add_argument("--output-file", default=OUTPUT_FILE,
+                        help=f"Path to the output aggregated JSON file (default: {OUTPUT_FILE})")
+    
+    args = parser.parse_args()
+    main(args)

--- a/scripts/gemini_analyzer.py
+++ b/scripts/gemini_analyzer.py
@@ -439,13 +439,13 @@ def save_output_data(output_data: dict, output_path: str) -> None:
 def get_output_filename(input_filename: str) -> str:
     """Erzeugt einen Ausgabedateinamen basierend auf dem Eingabedateinamen."""
     base_name = os.path.basename(input_filename)
-    # Extrahiere die ID aus dem Dateinamen (erster Teil vor dem Unterstrich)
-    id_match = re.match(r'(\d+)_', base_name)
+    # Extrahiere die ID aus dem Dateinamen (Teil vor "_transcript.json")
+    id_match = re.match(r'(.*)_transcript\.json', base_name)
     if id_match:
-        episode_id = id_match.group(1)
-        return f"{episode_id}.json"
+        primary_id = id_match.group(1)
+        return f"{primary_id}.json"
     else:
-        # Fallback: Entferne "_transcript" und ändere die Erweiterung zu "_gegenwartscheck.json"
+        # Fallback, falls das Muster nicht passt (sollte nicht vorkommen bei korrekten Eingabedateien)
         return base_name.replace("_transcript.json", "_gegenwartscheck.json")
 
 def get_existing_analysis(output_path: str) -> Optional[dict]:

--- a/scripts/gemini_analyzer.py
+++ b/scripts/gemini_analyzer.py
@@ -440,7 +440,7 @@ def get_output_filename(input_filename: str) -> str:
     """Erzeugt einen Ausgabedateinamen basierend auf dem Eingabedateinamen."""
     base_name = os.path.basename(input_filename)
     # Extrahiere die ID aus dem Dateinamen (Teil vor "_transcript.json")
-    id_match = re.match(r'(.*)_transcript\.json', base_name)
+    id_match = re.match(r'(.+?)_transcript\.json', base_name)
     if id_match:
         primary_id = id_match.group(1)
         return f"{primary_id}.json"

--- a/tests/test_gemini_analyzer_logic.py
+++ b/tests/test_gemini_analyzer_logic.py
@@ -1,0 +1,364 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock, call
+import json
+import os
+import sys
+from datetime import datetime
+
+# Add scripts directory to sys.path to allow importing gemini_analyzer
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
+
+from gemini_analyzer import (
+    load_transcript,
+    create_gemini_prompt,
+    analyze_transcript_with_gemini,
+    proofread_analysis_with_gemini,
+    create_output_data,
+    get_output_filename,
+    validate_output_schema,
+    extract_date_from_title, # Helper for create_output_data
+    setup_gemini_client # To mock its behavior if needed for client creation
+)
+
+# Sample Data for Tests
+sample_transcript_data = {
+    "episode_title": "Test Episode Title",
+    "apple_id": "12345apple",
+    "spotify_id": "67890spotify",
+    "filename_primary_id": "12345apple",
+    "release_date": "2023-01-15",
+    "transcript": [
+        {"speaker": "SPEAKER_01", "text": "Lars speaking.", "begin_seconds": 5},
+        {"speaker": "SPEAKER_00", "text": "Ijoma proposing something.", "begin_seconds": 10}
+    ]
+}
+
+sample_initial_analysis_result = {
+    "gegenwartsvorschlaege": [
+        {
+            "vorschlag": "Das Test-Phänomen",
+            "vorschlagender": "Ijoma",
+            "ist_hoerer": False,
+            "hoerer_name": None,
+            "begruendung": "Eine Test Begründung.",
+            "metaebene": None,
+            "punkt_erhalten": True,
+            "punkt_von": "Lars",
+            "tags": ["test", "python"],
+            "start_zeit": "10s"
+        },
+        {
+            "vorschlag": "Listener Idea",
+            "vorschlagender": "SPEAKER_01", # Not a host, should be defaulted
+            "ist_hoerer": True,
+            "hoerer_name": "A Listener",
+            "begruendung": "Listener reasoning.",
+            "tags": ["listener", "community"],
+            "start_zeit": "120"
+            # punkt_erhalten missing
+            # punkt_von missing
+        },
+        {
+            "vorschlag": "Old format",
+            "vorschlagender": "Lars",
+            "ist_hoerer": False,
+            "hoerer_name": None,
+            "begruendung": "Testing ende_zeit removal.",
+            "metaebene": None,
+            "punkt_erhalten": False,
+            "punkt_von": "Ijoma",
+            "tags": ["cleanup"],
+            "start_zeit": "200s",
+            "ende_zeit": "210s" # Should be removed
+        }
+    ]
+}
+
+class TestGeminiAnalyzerLogic(unittest.TestCase):
+
+    # --- Tests for load_transcript ---
+    @patch("builtins.open", new_callable=mock_open, read_data='{"key": "value"}')
+    def test_load_transcript_success(self, mock_file):
+        expected_data = {"key": "value"}
+        result = load_transcript("dummy/path.json")
+        self.assertEqual(result, expected_data)
+        mock_file.assert_called_once_with("dummy/path.json", 'r', encoding='utf-8')
+
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_load_transcript_file_not_found(self, mock_file):
+        with self.assertRaises(FileNotFoundError):
+            load_transcript("dummy/nonexistent.json")
+        mock_file.assert_called_once_with("dummy/nonexistent.json", 'r', encoding='utf-8')
+
+    @patch("builtins.open", new_callable=mock_open, read_data='{"key": "value", invalid_json}')
+    def test_load_transcript_json_decode_error(self, mock_file):
+        with self.assertRaises(json.JSONDecodeError):
+            load_transcript("dummy/invalid.json")
+        mock_file.assert_called_once_with("dummy/invalid.json", 'r', encoding='utf-8')
+
+    # --- Tests for get_output_filename ---
+    def test_get_output_filename_apple_id(self):
+        self.assertEqual(get_output_filename("12345apple_transcript.json"), "12345apple.json")
+        self.assertEqual(get_output_filename("/path/to/12345apple_transcript.json"), "12345apple.json")
+
+    def test_get_output_filename_complex_id(self):
+        self.assertEqual(get_output_filename("Some-Complex-ID_transcript.json"), "Some-Complex-ID.json")
+
+    def test_get_output_filename_numeric_id(self):
+        self.assertEqual(get_output_filename("numeric123_transcript.json"), "numeric123.json")
+    
+    def test_get_output_filename_alphanumeric_id_with_hyphens_and_underscores(self):
+        self.assertEqual(get_output_filename("abc-123_XYZ-789_transcript.json"), "abc-123_XYZ-789.json")
+
+    def test_get_output_filename_fallback(self):
+        self.assertEqual(get_output_filename("no_match.json"), "no_match_gegenwartscheck.json")
+        self.assertEqual(get_output_filename("another_transcript_but_no_match.txt"), "another_transcript_but_no_match_gegenwartscheck.txt")
+
+
+    # --- Tests for validate_output_schema ---
+    def test_validate_output_schema_valid(self):
+        valid_data = {
+            "episode_title": "Title",
+            "apple_id": "apple123",
+            "spotify_id": "spotify123",
+            "episode_date": "2023-01-01",
+            "gegenwartsvorschlaege": []
+        }
+        self.assertTrue(validate_output_schema(valid_data))
+
+    def test_validate_output_schema_missing_field(self):
+        invalid_data_missing_title = {
+            "apple_id": "apple123",
+            "spotify_id": "spotify123",
+            "episode_date": "2023-01-01",
+            "gegenwartsvorschlaege": []
+        }
+        with patch('logging.warning') as mock_log:
+            self.assertFalse(validate_output_schema(invalid_data_missing_title))
+            mock_log.assert_any_call("Fehlendes Feld im Output: episode_title")
+
+        invalid_data_missing_vorschlaege = {
+            "episode_title": "Title",
+            "apple_id": "apple123",
+            "spotify_id": "spotify123",
+            "episode_date": "2023-01-01"
+        }
+        with patch('logging.warning') as mock_log:
+            self.assertFalse(validate_output_schema(invalid_data_missing_vorschlaege))
+            mock_log.assert_any_call("Fehlendes Feld im Output: gegenwartsvorschlaege")
+
+
+    def test_validate_output_schema_vorschlaege_not_list(self):
+        invalid_data = {
+            "episode_title": "Title",
+            "apple_id": "apple123",
+            "spotify_id": "spotify123",
+            "episode_date": "2023-01-01",
+            "gegenwartsvorschlaege": "not a list"
+        }
+        with patch('logging.warning') as mock_log:
+            self.assertFalse(validate_output_schema(invalid_data))
+            mock_log.assert_any_call("'gegenwartsvorschlaege' ist nicht vom Typ Liste.")
+
+    # --- Tests for create_gemini_prompt ---
+    def test_create_gemini_prompt_basic_structure(self):
+        prompt = create_gemini_prompt(sample_transcript_data)
+        self.assertIn(sample_transcript_data["episode_title"], prompt)
+        
+        expected_transcript_segment1 = "SPEAKER_01: Lars speaking.\n\n"
+        expected_transcript_segment2 = "SPEAKER_00: Ijoma proposing something.\n\n"
+        self.assertIn(expected_transcript_segment1, prompt)
+        self.assertIn(expected_transcript_segment2, prompt)
+        
+        # Check for key instructions in the prompt
+        self.assertIn("Identifiziere alle \"Gegenwartsvorschläge\"", prompt)
+        self.assertIn("Formatiere deine Antwort als JSON mit folgendem Schema:", prompt)
+        self.assertIn("\"vorschlag\": \"Name des Vorschlags\"", prompt) # Example field
+        self.assertIn("WICHTIG:", prompt)
+
+    # --- Tests for create_output_data ---
+    def test_create_output_data_basic_fields(self):
+        output = create_output_data(sample_transcript_data, sample_initial_analysis_result)
+        self.assertIsNotNone(output)
+        self.assertEqual(output["episode_title"], sample_transcript_data["episode_title"])
+        self.assertEqual(output["apple_id"], sample_transcript_data["apple_id"])
+        self.assertEqual(output["spotify_id"], sample_transcript_data["spotify_id"])
+        self.assertEqual(output["episode_date"], sample_transcript_data["release_date"])
+        # filename_primary_id is NOT directly part of the output structure of create_output_data
+        # it's used by the calling context (e.g. process_transcript) to determine the output filename
+
+    def test_create_output_data_vorschlaege_processing(self):
+        output = create_output_data(sample_transcript_data, sample_initial_analysis_result)
+        self.assertIsNotNone(output)
+        vorschlaege = output["gegenwartsvorschlaege"]
+        
+        # First vorschlag (explicit values)
+        self.assertEqual(vorschlaege[0]["vorschlag"], "Das Test-Phänomen")
+        self.assertEqual(vorschlaege[0]["vorschlagender"], "Ijoma")
+        self.assertTrue(vorschlaege[0]["punkt_erhalten"])
+        self.assertEqual(vorschlaege[0]["punkt_von"], "Lars")
+        self.assertEqual(vorschlaege[0]["start_zeit"], "10") # 's' stripped
+
+        # Second vorschlag (defaults and listener)
+        self.assertEqual(vorschlaege[1]["vorschlag"], "Listener Idea")
+        self.assertEqual(vorschlaege[1]["vorschlagender"], "Lars") # Defaulted for listener
+        self.assertFalse(vorschlaege[1]["punkt_erhalten"]) # Defaulted
+        self.assertIsNone(vorschlaege[1]["punkt_von"]) # Defaulted
+        self.assertEqual(vorschlaege[1]["start_zeit"], "120")
+
+        # Third vorschlag (ende_zeit removal)
+        self.assertNotIn("ende_zeit", vorschlaege[2])
+        self.assertEqual(vorschlaege[2]["start_zeit"], "200")
+
+
+    @patch('gemini_analyzer.datetime')
+    def test_create_output_data_date_handling(self, mock_datetime):
+        # 1. Uses release_date if available
+        transcript_with_release_date = {**sample_transcript_data, "release_date": "2024-03-10"}
+        output = create_output_data(transcript_with_release_date, sample_initial_analysis_result)
+        self.assertEqual(output["episode_date"], "2024-03-10")
+
+        # 2. Uses upload_date if release_date is missing
+        transcript_with_upload_date = {**sample_transcript_data, "release_date": None, "upload_date": "2024-03-11"}
+        output = create_output_data(transcript_with_upload_date, sample_initial_analysis_result)
+        self.assertEqual(output["episode_date"], "2024-03-11")
+
+        # 3. Extracts from title if both are missing
+        mock_datetime.now.return_value = datetime(2023, 7, 15) # For fallback if title has no date
+        transcript_with_title_date = {**sample_transcript_data, "release_date": None, "upload_date": None, "episode_title": "Episode from 2022"}
+        output = create_output_data(transcript_with_title_date, sample_initial_analysis_result)
+        self.assertEqual(output["episode_date"], "2022-01-01") # extract_date_from_title logic
+
+        # 4. Fallback to current date (mocked) if no date in title
+        transcript_no_date_info = {**sample_transcript_data, "release_date": None, "upload_date": None, "episode_title": "Timeless Episode"}
+        output = create_output_data(transcript_no_date_info, sample_initial_analysis_result)
+        self.assertEqual(output["episode_date"], "2023-07-15") # From mocked datetime.now() via extract_date_from_title
+        
+        # 5. Handles ISO datetime string with time for release_date
+        transcript_with_iso_datetime = {**sample_transcript_data, "release_date": "2024-03-10T10:00:00Z"}
+        output = create_output_data(transcript_with_iso_datetime, sample_initial_analysis_result)
+        self.assertEqual(output["episode_date"], "2024-03-10")
+
+    def test_create_output_data_empty_analysis(self):
+        empty_analysis = {"gegenwartsvorschlaege": []}
+        output = create_output_data(sample_transcript_data, empty_analysis)
+        self.assertIsNotNone(output)
+        self.assertEqual(len(output["gegenwartsvorschlaege"]), 0)
+
+    def test_create_output_data_none_analysis(self):
+        output = create_output_data(sample_transcript_data, None)
+        self.assertIsNone(output)
+        
+        output_malformed = create_output_data(sample_transcript_data, {"foo": "bar"}) # missing gegenwartsvorschlaege
+        self.assertIsNone(output)
+
+    def test_extract_date_from_title(self):
+        self.assertEqual(extract_date_from_title("An Episode from 2023 about stuff"), "2023-01-01")
+        self.assertEqual(extract_date_from_title("NoDateHere"), datetime.now().strftime("%Y-%m-%d"))
+        with patch('gemini_analyzer.datetime') as mock_dt:
+            mock_dt.now.return_value = datetime(2020, 5, 5)
+            self.assertEqual(extract_date_from_title("NoDateHere either"), "2020-05-05")
+
+    # --- Tests for analyze_transcript_with_gemini and proofread_analysis_with_gemini ---
+    # We'll use a helper for these as their core logic is similar
+    def _test_gemini_call_logic(self, function_to_test, model_name_in_call):
+        mock_client = MagicMock(spec=genai.Client)
+        mock_response = MagicMock()
+        
+        # Success Case
+        expected_dict = {"result": "success"}
+        mock_response.text = '```json\n' + json.dumps(expected_dict) + '\n```'
+        mock_client.models.generate_content.return_value = mock_response
+        
+        result = function_to_test(mock_client, sample_transcript_data)
+        self.assertEqual(result, expected_dict)
+        mock_client.models.generate_content.assert_called_once()
+        args, kwargs = mock_client.models.generate_content.call_args
+        self.assertEqual(kwargs['model'], model_name_in_call)
+
+        # JSON Extraction without markdown
+        mock_client.reset_mock()
+        mock_response.text = json.dumps(expected_dict)
+        mock_client.models.generate_content.return_value = mock_response
+        result = function_to_test(mock_client, sample_transcript_data)
+        self.assertEqual(result, expected_dict)
+
+        # JSON Decode Error
+        mock_client.reset_mock()
+        mock_response.text = '{"bad": "json"' # Malformed
+        mock_client.models.generate_content.return_value = mock_response
+        with patch('logging.warning') as mock_log:
+            result = function_to_test(mock_client, sample_transcript_data)
+            # proofread returns initial analysis on error, analyze returns None
+            if "proofread" in function_to_test.__name__:
+                 self.assertEqual(result, sample_transcript_data) # sample_transcript_data is used as initial_analysis here
+            else:
+                self.assertIsNone(result)
+            mock_log.assert_any_call(unittest.mock.ANY, unittest.mock.ANY) # Check if logging.warning was called
+
+        # Rate Limit/Retry
+        mock_client.reset_mock()
+        # Simulate ResourceExhausted which should trigger retry
+        # For google.api_core.exceptions.ResourceExhausted, the message often contains "429" or "RESOURCE_EXHAUSTED"
+        error_429 = types.generation_types.BlockedPromptException("Simulated 429 error") 
+        # A more direct way to simulate the specific exception class if available,
+        # or ensure the string check in the SUT handles this.
+        # For this test, we rely on the string check in the SUT.
+        # Let's make it an exception that contains "429" in its string representation.
+        class MockResourceExhausted(Exception):
+            def __init__(self, message):
+                super().__init__(message)
+
+        mock_client.models.generate_content.side_effect = [
+            MockResourceExhausted("Error 429: Too many requests"), 
+            mock_response # Success on second try
+        ]
+        mock_response.text = json.dumps(expected_dict) # Ensure success response is valid JSON
+        
+        with patch('time.sleep') as mock_sleep:
+            result = function_to_test(mock_client, sample_transcript_data)
+            self.assertEqual(result, expected_dict)
+            self.assertEqual(mock_client.models.generate_content.call_count, 2)
+            mock_sleep.assert_called_once()
+
+        # API Error (Non-retryable)
+        mock_client.reset_mock()
+        mock_client.models.generate_content.side_effect = ValueError("Some other API error")
+        with patch('logging.warning') as mock_log:
+            result = function_to_test(mock_client, sample_transcript_data)
+            if "proofread" in function_to_test.__name__:
+                 self.assertEqual(result, sample_transcript_data)
+            else:
+                self.assertIsNone(result)
+            mock_log.assert_any_call(unittest.mock.ANY, unittest.mock.ANY)
+            self.assertEqual(mock_client.models.generate_content.call_count, 1) # No retry
+
+    def test_analyze_transcript_with_gemini(self):
+        # Note: For analyze_transcript_with_gemini, the second argument is transcript_data
+        # We pass sample_transcript_data as the 'transcript_data' argument.
+        self._test_gemini_call_logic(
+            lambda client, data: analyze_transcript_with_gemini(client, data),
+            "gemini-2.0-flash-thinking-exp-01-21" # Expected model for analyze
+        )
+
+    def test_proofread_analysis_with_gemini(self):
+        # Note: For proofread_analysis_with_gemini, the second argument is initial_analysis
+        # and the third is transcript_data. We'll use sample_initial_analysis_result for initial_analysis
+        # and sample_transcript_data for transcript_data.
+        # The lambda needs to be adjusted to reflect this.
+        self._test_gemini_call_logic(
+            lambda client, data: proofread_analysis_with_gemini(client, sample_initial_analysis_result, data),
+            "gemini-2.0-pro-exp-02-05" # Expected model for proofread
+        )
+
+        # Test case where initial_analysis is None or malformed for proofread
+        mock_client = MagicMock(spec=genai.Client)
+        result_none = proofread_analysis_with_gemini(mock_client, None, sample_transcript_data)
+        self.assertIsNone(result_none)
+        
+        result_malformed = proofread_analysis_with_gemini(mock_client, {"foo": "bar"}, sample_transcript_data)
+        self.assertEqual(result_malformed, {"foo": "bar"})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_spotify_fetch_logic.py
+++ b/tests/test_spotify_fetch_logic.py
@@ -1,0 +1,205 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+import json
+import os
+import sys
+import requests # Required for requests.exceptions.RequestException
+
+# Add scripts directory to sys.path to allow importing spotify_fetch
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
+
+from spotify_fetch import (
+    get_spotify_token,
+    get_podcast_episodes,
+    save_episodes,
+    # main # Not explicitly testing main logic here, but could be if needed
+)
+
+# Sample Data for Tests
+sample_spotify_episodes_page1 = {
+    "items": [{"id": "ep1", "name": "Episode 1", "release_date": "2023-01-01", "external_urls": {"spotify": "url1"}, "description": "Desc 1", "duration_ms": 1000}],
+    "next": "https://api.spotify.com/v1/shows/dummy_show_id/episodes?offset=1&limit=1",
+    "total": 2,
+    "limit": 1,
+    "offset": 0
+}
+
+sample_spotify_episodes_page2 = {
+    "items": [{"id": "ep2", "name": "Episode 2", "release_date": "2023-01-08", "external_urls": {"spotify": "url2"}, "description": "Desc 2", "duration_ms": 2000}],
+    "next": None,
+    "total": 2,
+    "limit": 1,
+    "offset": 1
+}
+
+class TestSpotifyFetchLogic(unittest.TestCase):
+
+    # --- Tests for get_spotify_token ---
+    @patch('requests.post')
+    def test_get_spotify_token_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "test_token", "expires_in": 3600}
+        mock_response.raise_for_status = MagicMock() # Ensure it doesn't raise for success
+        mock_post.return_value = mock_response
+
+        token = get_spotify_token("test_client_id", "test_client_secret")
+
+        self.assertEqual(token, "test_token")
+        mock_post.assert_called_once_with(
+            "https://accounts.spotify.com/api/token",
+            headers={"Authorization": "Basic dGVzdF9jbGllbnRfaWQ6dGVzdF9jbGllbnRfc2VjcmV0"},
+            data={"grant_type": "client_credentials"}
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('requests.post')
+    def test_get_spotify_token_api_error(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("API Error")
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            get_spotify_token("test_client_id", "test_client_secret")
+        mock_post.assert_called_once()
+        mock_response.raise_for_status.assert_called_once()
+
+
+    @patch('requests.post', side_effect=requests.exceptions.RequestException("Network Error"))
+    def test_get_spotify_token_request_exception(self, mock_post):
+        with self.assertRaises(requests.exceptions.RequestException):
+            get_spotify_token("test_client_id", "test_client_secret")
+        mock_post.assert_called_once()
+
+    # --- Tests for get_podcast_episodes ---
+    @patch('requests.get')
+    @patch('spotify_fetch.get_spotify_token', return_value="dummy_token")
+    def test_get_podcast_episodes_single_page_success(self, mock_get_token, mock_get):
+        mock_response = MagicMock()
+        # Simulate a scenario where the first page is the only page
+        single_page_data = {**sample_spotify_episodes_page1, "next": None}
+        mock_response.json.return_value = single_page_data
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        episodes = get_podcast_episodes("test_client_id", "test_client_secret", "dummy_show_id")
+        
+        expected_episodes = [{
+            "id": "ep1",
+            "title": "Episode 1",
+            "release_date": "2023-01-01",
+            "url": "url1",
+            "description": "Desc 1",
+            "duration_ms": 1000
+        }]
+        self.assertEqual(episodes, expected_episodes)
+        mock_get_token.assert_called_once_with("test_client_id", "test_client_secret")
+        mock_get.assert_called_once_with(
+            "https://api.spotify.com/v1/shows/dummy_show_id/episodes",
+            headers={"Authorization": "Bearer dummy_token"},
+            params={"limit": 50, "offset": 0, "market": "US"}
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('requests.get')
+    @patch('spotify_fetch.get_spotify_token', return_value="dummy_token")
+    def test_get_podcast_episodes_multi_page_success(self, mock_get_token, mock_get):
+        mock_response_page1 = MagicMock()
+        mock_response_page1.json.return_value = sample_spotify_episodes_page1
+        mock_response_page1.raise_for_status = MagicMock()
+
+        mock_response_page2 = MagicMock()
+        mock_response_page2.json.return_value = sample_spotify_episodes_page2
+        mock_response_page2.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [mock_response_page1, mock_response_page2]
+
+        episodes = get_podcast_episodes("test_client_id", "test_client_secret", "dummy_show_id")
+
+        expected_episodes = [
+            {"id": "ep1", "title": "Episode 1", "release_date": "2023-01-01", "url": "url1", "description": "Desc 1", "duration_ms": 1000},
+            {"id": "ep2", "title": "Episode 2", "release_date": "2023-01-08", "url": "url2", "description": "Desc 2", "duration_ms": 2000}
+        ]
+        self.assertEqual(episodes, expected_episodes)
+        mock_get_token.assert_called_once_with("test_client_id", "test_client_secret")
+        
+        calls = [
+            call("https://api.spotify.com/v1/shows/dummy_show_id/episodes", headers={"Authorization": "Bearer dummy_token"}, params={"limit": 50, "offset": 0, "market": "US"}),
+            call(sample_spotify_episodes_page1["next"], headers={"Authorization": "Bearer dummy_token"}, params={"limit": 50, "offset": 1, "market": "US"}) #The 'next' url already contains offset and limit, but the code overrides it
+        ]
+        mock_get.assert_has_calls(calls)
+        self.assertEqual(mock_get.call_count, 2)
+        mock_response_page1.raise_for_status.assert_called_once()
+        mock_response_page2.raise_for_status.assert_called_once()
+
+    @patch('requests.get')
+    @patch('spotify_fetch.get_spotify_token', return_value="dummy_token")
+    def test_get_podcast_episodes_api_error(self, mock_get_token, mock_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("API Error")
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            get_podcast_episodes("test_client_id", "test_client_secret", "dummy_show_id")
+        
+        mock_get_token.assert_called_once()
+        mock_get.assert_called_once() # Should fail on the first call
+        mock_response.raise_for_status.assert_called_once()
+
+
+    @patch('requests.get')
+    @patch('spotify_fetch.get_spotify_token', return_value="dummy_token")
+    def test_get_podcast_episodes_empty_response(self, mock_get_token, mock_get):
+        mock_response = MagicMock()
+        empty_data = {"items": [], "next": None, "total": 0, "limit": 50, "offset": 0}
+        mock_response.json.return_value = empty_data
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        episodes = get_podcast_episodes("test_client_id", "test_client_secret", "dummy_show_id")
+
+        self.assertEqual(episodes, [])
+        mock_get_token.assert_called_once()
+        mock_get.assert_called_once()
+
+
+    # --- Tests for save_episodes ---
+    @patch('os.makedirs')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.dump')
+    def test_save_episodes_success(self, mock_json_dump, mock_file_open, mock_os_makedirs):
+        sample_episodes_data = [
+            {"id": "ep1", "title": "Episode 1"},
+            {"id": "ep2", "title": "Episode 2"}
+        ]
+        output_filepath = "data/output/episodes.json"
+        expected_dir = os.path.dirname(output_filepath)
+
+        save_episodes(sample_episodes_data, output_filepath)
+
+        mock_os_makedirs.assert_called_once_with(expected_dir, exist_ok=True)
+        mock_file_open.assert_called_once_with(output_filepath, 'w', encoding='utf-8')
+        mock_json_dump.assert_called_once_with(sample_episodes_data, mock_file_open(), indent=2, ensure_ascii=False)
+
+    @patch('os.makedirs', side_effect=OSError("Failed to create directory"))
+    def test_save_episodes_makedirs_os_error(self, mock_os_makedirs):
+        sample_episodes_data = [{"id": "ep1"}]
+        output_filepath = "data/output/episodes.json"
+        
+        with self.assertRaises(OSError): # Or check if logger.error was called if there's try-except in SUT
+            save_episodes(sample_episodes_data, output_filepath)
+        mock_os_makedirs.assert_called_once()
+
+    @patch('os.makedirs') # Mock makedirs to prevent actual directory creation
+    @patch('builtins.open', side_effect=IOError("Failed to open file"))
+    def test_save_episodes_open_io_error(self, mock_file_open, mock_os_makedirs):
+        sample_episodes_data = [{"id": "ep1"}]
+        output_filepath = "data/output/episodes.json"
+        
+        with self.assertRaises(IOError): # Or check if logger.error was called
+            save_episodes(sample_episodes_data, output_filepath)
+        mock_os_makedirs.assert_called_once()
+        mock_file_open.assert_called_once_with(output_filepath, 'w', encoding='utf-8')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_spotify_fetch_logic.py
+++ b/tests/test_spotify_fetch_logic.py
@@ -124,7 +124,7 @@ class TestSpotifyFetchLogic(unittest.TestCase):
         
         calls = [
             call("https://api.spotify.com/v1/shows/dummy_show_id/episodes", headers={"Authorization": "Bearer dummy_token"}, params={"limit": 50, "offset": 0, "market": "US"}),
-            call(sample_spotify_episodes_page1["next"], headers={"Authorization": "Bearer dummy_token"}, params={"limit": 50, "offset": 1, "market": "US"}) #The 'next' url already contains offset and limit, but the code overrides it
+            call(sample_spotify_episodes_page1["next"], headers={"Authorization": "Bearer dummy_token"}) # Use the 'next' URL as-is without overriding its query parameters
         ]
         mock_get.assert_has_calls(calls)
         self.assertEqual(mock_get.call_count, 2)


### PR DESCRIPTION
This commit introduces a comprehensive system for analyzing podcast episodes and presenting the findings on a GitHub Pages website.

Key changes include:

1.  **Workflow Enhancements:**
    *   Standardized ID handling (using Apple ID or Spotify ID as a
      `PRIMARY_ID`) across workflows (`process-episodes.yml`,
      `extract-transcript.yml`, `gemini-analyzer.yml`) to ensure
      consistent data flow from raw caches to final analyses.
    *   Modified `gemini-analyzer.yml` to include a new job,
      `build-and-deploy-site`, which automates the data aggregation
      for the website and deploys it to GitHub Pages.

2.  **New Scripts:**
    *   `scripts/aggregate_data.py`: Aggregates all individual episode
      analyses and episode metadata into a single `docs/site_data.json`
      file consumed by the GitHub Pages site.

3.  **GitHub Pages Site:**
    *   Created `docs/index.html`, `docs/style.css`, and `docs/main.js`
      to build a single-page application.
    *   The site displays a searchable and filterable list of
      "Gegenwartsvorschläge" (suggestions from the podcast).
    *   It also shows statistics like suggestions per host, success
      rates, and tag frequencies.

4.  **Unit Tests:**
    *   Added comprehensive unit tests for `scripts/gemini_analyzer.py`
      (in `tests/test_gemini_analyzer_logic.py`) and
      `scripts/spotify_fetch.py` (in `tests/test_spotify_fetch_logic.py`),
      covering core functionalities, edge cases, and error handling.

5.  **Documentation:**
    *   Created a `README.md` file detailing the project structure,
      data pipeline, key scripts, and workflow operations.

These changes fulfill your request to improve the scripts, ensure sensible invocation via GitHub Actions, and create a GitHub Pages static site with searchable results and statistics.